### PR TITLE
Logout user when trying to verify account

### DIFF
--- a/app/Http/Middleware/RedirectIfAuthenticated.php
+++ b/app/Http/Middleware/RedirectIfAuthenticated.php
@@ -18,9 +18,13 @@ class RedirectIfAuthenticated
     public function handle($request, Closure $next, $guard = null)
     {
         if (Auth::guard($guard)->check()) {
-            return redirect('/dashboard');
+            if ($request->is('account/verify/*')) {
+                Auth::logout();
+            } else {
+                return redirect('/dashboard');
+            }
         }
-
+        
         return $next($request);
     }
 }


### PR DESCRIPTION
If the user try to verify a new account and there is a user already authenticaded, the system force the current loged in user to logout and verify the new user account as intended.